### PR TITLE
SwaggerDoc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Swiki
 
-**Swiki** is a [MediaWiki](https://www.mediawiki.org/wiki/MediaWiki) [extension](https://www.mediawiki.org/wiki/Extension:Swiki) that allows you to seamlessly embed [Swagger UI](https://github.com/swagger-api/swagger-ui) directly into your wiki pages using a simple `<swiki>` tag. It includes a recent build of Swagger UI, providing full support for displaying your API documentation. Swiki also includes [Swagger Dark Theme](https://github.com/Amoenus/SwaggerDark), which is nicely integrated with MediaWiki skins that support dark mode, such as Vector-2022 and Minerva.
+**Swiki** is a [MediaWiki](https://www.mediawiki.org/wiki/MediaWiki) [extension](https://www.mediawiki.org/wiki/Extension:Swiki) that allows you to seamlessly embed [Swagger UI](https://github.com/swagger-api/swagger-ui) directly into your wiki pages using a simple `<swiki>` tag. It includes a recent build of Swagger UI, providing full support for displaying your API documentation.
 
 You can load OpenAPI or Swagger specifications in several ways: by embedding inline JSON, uploading a specification, referencing dedicated wiki pages that contain the specification, or linking to an external specification URL.
+
+Swiki also includes [Swagger Dark Theme](https://github.com/Amoenus/SwaggerDark), which is nicely integrated with MediaWiki skins that support dark mode, such as Vector-2022 and Minerva. Additionally, it can parse tags from third-party extensions like [SwaggerDoc](https://github.com/Griboedow/SwaggerDoc).
 
 > 🚀 **This repository follows the MediaWiki release branches compatibility policy.** You can find dedicated branches for supported versions here:
 >
@@ -40,6 +42,8 @@ Optional configuration variables:
 - `$wgSwikiForceColorScheme`: Forces a specific color scheme in Swagger UI. Accepted values are `auto`, `light`, or `dark`. Default: `auto`.
 
 - `$wgSwikiValidatorUrl`: Specifies a Swagger validator for displaying a [validator badge](https://github.com/swagger-api/validator-badge), e.g., `https://validator.swagger.io/validator`. Default: `null`.
+
+- `$wgSwikiEnableSwaggerDocHook`: Enables parsing of SwaggerDoc tags when set to `true`. Default: `false`.
 
 To allow users to upload OpenAPI/Swagger specifications, ensure that file uploads are [properly configured](https://www.mediawiki.org/wiki/Manual:Configuring_file_uploads) and that `.json` is an allowed file extension:
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Swiki",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"author": "Vuhuy Luu",
 	"url": "https://github.com/vuhuy/Swiki",
 	"descriptionmsg": "swiki-desc",

--- a/extension.json
+++ b/extension.json
@@ -65,6 +65,10 @@
 		"SwikiValidatorUrl": {
 			"value": null,
 			"description": "Validate the provided specification against a validator, e.g. https:///validator.swagger.io/validator. Default value: null."
+		},
+		"SwikiEnableSwaggerDocHook": {
+			"value": false,
+			"description": "Enables parsing of the SwaggerDoc tags. Default value: false."
 		}
 	},
 	"ConfigRegistry": {

--- a/tests/data/SwaggerDoc_Invalid_Urls.html
+++ b/tests/data/SwaggerDoc_Invalid_Urls.html
@@ -1,0 +1,1 @@
+<SwaggerDoc specUrls="[]" />

--- a/tests/data/SwaggerDoc_Valid_Url.html
+++ b/tests/data/SwaggerDoc_Valid_Url.html
@@ -1,0 +1,1 @@
+<SwaggerDoc specUrl="/extensions/Swiki/tests/data/openapi.json" />

--- a/tests/data/SwaggerDoc_Valid_Urls.html
+++ b/tests/data/SwaggerDoc_Valid_Urls.html
@@ -1,0 +1,1 @@
+<SwaggerDoc specUrls="[{'url': '/extensions/Swiki/tests/data/openapi.json', 'name': 'Petstore 3'},{'url': '/extensions/Swiki/tests/data/swagger.json', 'name': 'Petstore 2'}]" />

--- a/tests/pytest/test_hook.py
+++ b/tests/pytest/test_hook.py
@@ -13,6 +13,9 @@ def test_hook_control(browser, base_url):
     assert_js_errors(browser)
 
 @pytest.mark.parametrize("page,should_be_valid,should_be_standalone", [
+    ("SwaggerDoc_Invalid_Urls", False, False),
+    ("SwaggerDoc_Valid_Url", True, True),
+    ("SwaggerDoc_Valid_Urls", True, True),
     ("Swiki_Invalid_Inline", False, False),
     ("Swiki_Invalid_Urls", False, False),
     ("Swiki_Valid_Inline", True, False),

--- a/tests/scripts/prepare.sh
+++ b/tests/scripts/prepare.sh
@@ -11,9 +11,13 @@ php maintenance/run.php install.php \
     --pass=mediawiki1234 \
     'Swikipedia' 'Swiki' &&
 echo "wfLoadExtension( 'Swiki' );" >> LocalSettings.php  &&
+echo "\$wgSwikiEnableSwaggerDocHook = true;" >> LocalSettings.php &&
 echo "\$wgRateLimits = [];" >> LocalSettings.php &&
 apachectl graceful &&
 php maintenance/run.php edit.php --conf LocalSettings.php Control < extensions/Swiki/tests/data/Control.html &&
+php maintenance/run.php edit.php --conf LocalSettings.php SwaggerDoc_Invalid_Urls < extensions/Swiki/tests/data/SwaggerDoc_Invalid_Urls.html &&
+php maintenance/run.php edit.php --conf LocalSettings.php SwaggerDoc_Valid_Url < extensions/Swiki/tests/data/SwaggerDoc_Valid_Url.html &&
+php maintenance/run.php edit.php --conf LocalSettings.php SwaggerDoc_Valid_Urls < extensions/Swiki/tests/data/SwaggerDoc_Valid_Urls.html &&
 php maintenance/run.php edit.php --conf LocalSettings.php Swiki_Invalid_Inline < extensions/Swiki/tests/data/Swiki_Invalid_Inline.html &&
 php maintenance/run.php edit.php --conf LocalSettings.php Swiki_Invalid_Urls < extensions/Swiki/tests/data/Swiki_Invalid_Urls.html &&
 php maintenance/run.php edit.php --conf LocalSettings.php Swiki_Valid_Inline < extensions/Swiki/tests/data/Swiki_Valid_Inline.html &&


### PR DESCRIPTION
Adds support to parse and render tags from the [SwaggerDoc](https://github.com/Griboedow/SwaggerDoc) extension. SwaggerDoc has been broken since the release of MediaWiki 1.43.