### PR TITLE
Detect PHP errors during integration tests

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from pathlib import Path
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
@@ -18,6 +19,13 @@ def browser(request):
         driver = webdriver.Chrome(options=options)
     elif request.param == "firefox":
         options = FirefoxOptions()
+
+        # Workaround for Firefox snap on Ubuntu systems. 
+        # The test will run, but you will get errors when it tries to terminate Firefox.
+        snap_firefox_path = Path("/snap/firefox/current/usr/lib/firefox/firefox")
+        if snap_firefox_path.exists():
+            options.binary_location = str(snap_firefox_path)
+
         options.add_argument("--headless")
         driver = webdriver.Firefox(options=options)
     else:

--- a/tests/pytest/test_hook.py
+++ b/tests/pytest/test_hook.py
@@ -2,7 +2,7 @@ import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from tests.utils.helpers import assert_js_errors, save_screenshot
+from tests.utils.helpers import assert_js_errors, assert_php_errors, save_screenshot
 
 
 @pytest.mark.dependency(name="hook_control_test")
@@ -10,7 +10,14 @@ def test_hook_control(browser, base_url):
     """Javascript control test without using the extension."""
 
     browser.get(f"{base_url}/index.php/Control")
-    assert_js_errors(browser)
+
+    try:
+        assert_js_errors(browser)
+        assert_php_errors(browser)
+
+    except Exception as e:
+        save_screenshot(browser, f'Hook-Control-Fail')
+        raise
 
 @pytest.mark.parametrize("page,should_be_valid,should_be_standalone", [
     ("SwaggerDoc_Invalid_Urls", False, False),
@@ -28,8 +35,10 @@ def test_hook_page(browser, base_url, page, should_be_valid, should_be_standalon
     """Test Swiki hook and Swagger UI rendering result of the hook."""
 
     browser.get(f"{base_url}/index.php/{page}")
-
+    
     try:
+        assert_php_errors(browser)
+
         if should_be_valid:
             # Expect hook parser says Swagger UI should render this tag.
             browser.find_element(By.CSS_SELECTOR, ".mw-ext-swiki-render")

--- a/tests/pytest/test_visualeditor.py
+++ b/tests/pytest/test_visualeditor.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from tests.utils.helpers import assert_js_errors, save_screenshot, wait_for_visualeditor
+from tests.utils.helpers import assert_js_errors, assert_php_errors, save_screenshot, wait_for_visualeditor
 
 
 field_params = pytest.mark.parametrize(
@@ -37,8 +37,8 @@ def test_visualeditor_control(browser, base_url):
     """Javascript control test without using the extension."""
 
     browser.get(f"{base_url}/index.php?title=Control&veaction=edit")
+    assert_php_errors(browser)
     WebDriverWait(browser, 5).until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".oo-ui-toolbar")))
-
     assert_js_errors(browser)
 
 @field_params
@@ -50,6 +50,7 @@ def test_visualeditor_edit(browser, base_url, name, click_selector, input_select
     input_selector = click_selector if input_selector == "" else input_selector
 
     try:
+        assert_php_errors(browser)
         wait_for_visualeditor(browser)
 
         # Use node to open Swiki dialog.
@@ -81,6 +82,7 @@ def test_visualeditor_insert(browser, base_url, name, click_selector, input_sele
     input_selector = click_selector if input_selector == "" else input_selector
 
     try:
+        assert_php_errors(browser)
         wait_for_visualeditor(browser)
 
         # Use toolbar to open Swiki dialog.

--- a/tests/scripts/prepare.sh
+++ b/tests/scripts/prepare.sh
@@ -10,6 +10,12 @@ php maintenance/run.php install.php \
     --lang=en \
     --pass=mediawiki1234 \
     'Swikipedia' 'Swiki' &&
+sed -i "1a\\
+error_reporting( -1 );\\
+ini_set( 'display_errors', 1 );\\
+\$wgShowExceptionDetails = true;\\
+\$wgShowDBErrorBacktrace = true;
+" LocalSettings.php &&
 echo "wfLoadExtension( 'WikiEditor' );" >> LocalSettings.php  &&
 echo "wfLoadExtension( 'CodeEditor' );" >> LocalSettings.php  &&
 echo "wfLoadExtension( 'VisualEditor' );" >> LocalSettings.php  &&

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -16,6 +16,17 @@ def assert_js_errors(browser):
         errors = [log for log in logs if log["level"] == "SEVERE"]
         assert len(errors) == 0, f"Javascript errors detected: {errors}."
 
+def assert_php_errors(browser):
+    """Assert that there are no php errors on the current page."""
+
+    # Not ideal, but does the job.
+    src = browser.page_source.strip().lower()
+    assert "parse error: " not in src and "<b>parse error</b>: " not in src, f"PHP parse error detected."
+    assert "warning: " not in src and "<b>warning</b>: " not in src, f"PHP warning detected."
+    assert "fatal error: " not in src and "<b>fatal error</b>: " not in src, f"PHP fatal error detected."
+    assert "error: " not in src and "<b>error</b>: " not in src, f"PHP error detected."
+    assert "deprecated: " not in src and "<b>deprecated</b>: " not in src, f"PHP deprectation warning detected."
+
 def save_screenshot(browser, name):
     """Save a screenshot of the current page."""
 
@@ -40,3 +51,4 @@ def wait_for_visualeditor(browser):
         WebDriverWait(browser, 5).until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".oo-ui-iconElement-icon.oo-ui-icon-close"))).click()
     except TimeoutException:
         pass
+


### PR DESCRIPTION
Detect PHP errors during integration tests. Includes normal errors, fatal errors, but also warnings and deprecation warnings. It's technically not the correct tool, but it does the job just fine with with minimal effort and tech debt.