### PR TITLE
Add support for MW 1.44

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      MW_VERSION: '1.43'
+      MW_VERSION: '1.44'
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Swiki also includes [Swagger Dark Theme](https://github.com/Amoenus/SwaggerDark)
 
 > 🚀 **This repository follows the MediaWiki release branches compatibility policy.** You can find dedicated branches for supported versions here:
 >
-> - [Swiki for MediaWiki 1.43](https://github.com/vuhuy/Swiki/tree/REL1_43) (current LTS version)
-> - [Swiki for MediaWiki 1.42](https://github.com/vuhuy/Swiki/tree/REL1_42) (legacy stable version)
+> - [Swiki for MediaWiki 1.44](https://github.com/vuhuy/Swiki/tree/REL1_44) (current stable version)
+> - [Swiki for MediaWiki 1.43](https://github.com/vuhuy/Swiki/tree/REL1_43) (legacy stable and current LTS version)
 > - [Swiki for MediaWiki 1.39](https://github.com/vuhuy/Swiki/tree/REL1_39) (legacy LTS version)
 
 ## Screenshots
@@ -233,7 +233,7 @@ cd test/scripts
 Optionally, you can specify a supported MediaWiki version, e.g.:
 
 ```bash
-./run.sh 1.43
+./run.sh 1.44
 ```
 
 ## Credits

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"license-name": "MIT",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.43.0"
+		"MediaWiki": ">= 1.44.0"
 	},
 	"MessagesDirs": {
 		"Swiki": [

--- a/tests/scripts/run.sh
+++ b/tests/scripts/run.sh
@@ -8,7 +8,7 @@
 #
 # Examples:
 #   ./run_test.sh
-#   ./run_test.sh 1.43
+#   ./run_test.sh 1.44
 
 # Set working directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,8 +28,8 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Choose MediaWiki version (default to 1.43)
-MW_VERSION="${1:-1.43}"
+# Choose MediaWiki version (default to 1.44)
+MW_VERSION="${1:-1.44}"
 echo -e "\n\n==> Using MediaWiki version: $MW_VERSION"
 
 # Setup virtual env


### PR DESCRIPTION
MediaWiki 1.44 has been released a few months ago. This fixes all breaking changes with this MediaWiki release.