### PR TITLE
Fix ResourceLoader path

### DIFF
--- a/modules/swiki.js
+++ b/modules/swiki.js
@@ -60,7 +60,7 @@ mw.loader.using('mediawiki.util', () => {
 		// Set up shadow DOM.
 		const style = document.createElement('link');
 		style.setAttribute('rel', 'stylesheet');
-		style.setAttribute('href', '/load.php?modules=ext.swiki.swaggerui.styles&only=styles');
+		style.setAttribute('href', mw.util.wikiScript( 'load' ) + '?modules=ext.swiki.swaggerui.styles&only=styles');
 
 		const swagger = document.createElement('div');
 		swagger.className = 'swagger-container';


### PR DESCRIPTION
Standard MediaWiki installations have their $wgScriptPath set to `/w`. The `load.php` would therefore be available under `/w/load.php` not `/load.php`. Using the proper `mw.util` abstraction to create the endpoint base URL will fix this and and other `$wgScriptPath` setting.

This change should be cherry-picked to the other `REL1_*` branches as well.