### PR TITLE
Release Swiki v1.2.1 REL1_45

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
-# Swiki
+# Swiki for MediaWiki 1.45
 
 **Swiki** is a [MediaWiki](https://www.mediawiki.org/wiki/MediaWiki) [extension](https://www.mediawiki.org/wiki/Extension:Swiki) that allows you to seamlessly embed [Swagger UI](https://github.com/swagger-api/swagger-ui) directly into your wiki pages using a simple `<swiki>` tag or through the [VisualEditor](https://www.mediawiki.org/wiki/VisualEditor). It includes a recent build of Swagger UI, providing full support for displaying your API documentation.
 
 You can load OpenAPI or Swagger specifications in several ways: by embedding inline JSON, uploading a specification, referencing dedicated wiki pages that contain the specification, or linking to an external specification URL.
 
 Swiki also includes [Swagger Dark Theme](https://github.com/Amoenus/SwaggerDark), which is nicely integrated with MediaWiki skins that support dark mode, such as Vector-2022 and Minerva. Additionally, it can parse tags from third-party extensions like [SwaggerDoc](https://github.com/Griboedow/SwaggerDoc).
-
-> 🚀 **This repository follows the MediaWiki release branches compatibility policy.** You can find dedicated branches for supported versions here:
->
-> - [Swiki for MediaWiki 1.45](https://github.com/5uhuy/Swiki/tree/REL1_45) (current stable version)
-> - [Swiki for MediaWiki 1.44](https://github.com/vuhuy/Swiki/tree/REL1_44) (legacy stable version )
-> - [Swiki for MediaWiki 1.43](https://github.com/vuhuy/Swiki/tree/REL1_43) (legacy stable and current LTS version)
 
 ## Screenshots
 
@@ -36,7 +30,7 @@ Clone the extension into your MediaWiki `extensions` directory:
 
 ```bash
 cd extensions/
-git clone https://github.com/vuhuy/Swiki
+git clone --branch REL1_45 https://github.com/vuhuy/Swiki
 ```
 
 Then enable it by adding the following line to your `LocalSettings.php`:


### PR DESCRIPTION
Release Swiki v1.2.1 to supported MediaWiki release branches.